### PR TITLE
Normalize naming in SEM force/receiver internals

### DIFF
--- a/DSpecM1D/src/NormClass.h
+++ b/DSpecM1D/src/NormClass.h
@@ -12,14 +12,14 @@ template <typename FLOAT> class prem_norm {
 public:
   prem_norm() = default;
 
-  FLOAT LengthNorm() const { return _length_norm; }
-  FLOAT MassNorm() const { return _mass_norm; }
-  FLOAT TimeNorm() const { return _time_norm; }
+  FLOAT LengthNorm() const { return m_lengthNorm; }
+  FLOAT MassNorm() const { return m_massNorm; }
+  FLOAT TimeNorm() const { return m_timeNorm; }
 
 private:
-  FLOAT _length_norm = 1000.0;
-  FLOAT _mass_norm = 5515.0 * std::pow(_length_norm, 3.0);
-  FLOAT _time_norm = 1.0 / std::sqrt(PI * 6.67230e-11 * 5515.0);
+  FLOAT m_lengthNorm = 1000.0;
+  FLOAT m_massNorm = 5515.0 * std::pow(m_lengthNorm, 3.0);
+  FLOAT m_timeNorm = 1.0 / std::sqrt(PI * 6.67230e-11 * 5515.0);
 };
 
 #endif   // NORM_CLASS_GUARD_H

--- a/DSpecM1D/src/SEM/SEMForceRadial.h
+++ b/DSpecM1D/src/SEM/SEMForceRadial.h
@@ -7,8 +7,8 @@ namespace Full1D {
 
 Eigen::MatrixXcd
 SEM::calculateForceR(SourceInfo::EarthquakeCMT &cmt) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgR(1, m_mesh.NE() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgR(1, m_mesh.NE() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(totlen, 1);
 
   double rad_source = _SourceRadius(cmt);
@@ -28,7 +28,7 @@ SEM::calculateForceR(SourceInfo::EarthquakeCMT &cmt) {
       auto pleg =
           Interpolation::LagrangePolynomial(vec_nodes.begin(), vec_nodes.end());
 
-      for (int idxq = 0; idxq < NQ; ++idxq) {
+      for (int idxq = 0; idxq < nq; ++idxq) {
         auto w_val = pleg(idxq, rad_source) / rad_source;
         auto w_deriv = pleg.Derivative(idxq, rad_source);
         auto idx_u = this->ltgR(0, idx, idxq);
@@ -47,8 +47,8 @@ SEM::calculateForceR(SourceInfo::EarthquakeCMT &cmt) {
 
 Eigen::MatrixXcd
 SEM::calculateForceRedR(SourceInfo::EarthquakeCMT &cmt) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgR(1, m_mesh.NE() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgR(1, m_mesh.NE() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(totlen, 1);
 
   double rad_source = _SourceRadius(cmt);
@@ -66,7 +66,7 @@ SEM::calculateForceRedR(SourceInfo::EarthquakeCMT &cmt) {
       auto pleg =
           Interpolation::LagrangePolynomial(vec_nodes.begin(), vec_nodes.end());
 
-      for (int idxq = 0; idxq < NQ; ++idxq) {
+      for (int idxq = 0; idxq < nq; ++idxq) {
         auto w_val = pleg(idxq, rad_source) / rad_source;
         auto w_deriv = pleg.Derivative(idxq, rad_source);
         auto idx_u = this->ltgR(0, idx, idxq);

--- a/DSpecM1D/src/SEM/SEMForceSpheroidal.h
+++ b/DSpecM1D/src/SEM/SEMForceSpheroidal.h
@@ -7,8 +7,8 @@ namespace Full1D {
 
 Eigen::MatrixXcd
 SEM::calculateForce(SourceInfo::EarthquakeCMT &cmt, int idxl) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgS(2, m_mesh.NE() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgS(2, m_mesh.NE() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(totlen, 2 * idxl + 1);
   double kval =
       std::sqrt(static_cast<double>(idxl) * (static_cast<double>(idxl) + 1.0));
@@ -43,7 +43,7 @@ SEM::calculateForce(SourceInfo::EarthquakeCMT &cmt, int idxl) {
       auto pleg =
           Interpolation::LagrangePolynomial(vec_nodes.begin(), vec_nodes.end());
 
-      for (int idxq = 0; idxq < NQ; ++idxq) {
+      for (int idxq = 0; idxq < nq; ++idxq) {
         auto w_val = pleg(idxq, rad_source) / rad_source;
         auto w_deriv = pleg.Derivative(idxq, rad_source);
         auto idx_u = this->ltgS(0, idx, idxq);
@@ -82,8 +82,8 @@ SEM::calculateForce(SourceInfo::EarthquakeCMT &cmt, int idxl) {
 
 Eigen::MatrixXcd
 SEM::calculateForceAll(SourceInfo::EarthquakeCMT &cmt, int idxl) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgS(2, m_mesh.NE() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgS(2, m_mesh.NE() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(totlen, 4);
   double kval =
       std::sqrt(static_cast<double>(idxl) * (static_cast<double>(idxl) + 1.0));
@@ -98,7 +98,7 @@ SEM::calculateForceAll(SourceInfo::EarthquakeCMT &cmt, int idxl) {
       auto pleg =
           Interpolation::LagrangePolynomial(vec_nodes.begin(), vec_nodes.end());
 
-      for (int idxq = 0; idxq < NQ; ++idxq) {
+      for (int idxq = 0; idxq < nq; ++idxq) {
         auto w_val = pleg(idxq, rad_source) / rad_source;
         auto w_deriv = pleg.Derivative(idxq, rad_source);
         auto idx_u = this->ltgS(0, idx, idxq);
@@ -116,8 +116,8 @@ SEM::calculateForceAll(SourceInfo::EarthquakeCMT &cmt, int idxl) {
 
 Eigen::MatrixXcd
 SEM::calculateForceCoefficients(SourceInfo::EarthquakeCMT &cmt, int idxl) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgS(2, m_mesh.NE() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgS(2, m_mesh.NE() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(2 * idxl + 1, 4);
   double kval =
       std::sqrt(static_cast<double>(idxl) * (static_cast<double>(idxl) + 1.0));

--- a/DSpecM1D/src/SEM/SEMForceToroidal.h
+++ b/DSpecM1D/src/SEM/SEMForceToroidal.h
@@ -7,8 +7,8 @@ namespace Full1D {
 
 Eigen::MatrixXcd
 SEM::calculateForceT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgT(m_eu - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgT(m_eu - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(totlen, 2 * idxl + 1);
   double kval =
       std::sqrt(static_cast<double>(idxl) * (static_cast<double>(idxl) + 1.0));
@@ -41,7 +41,7 @@ SEM::calculateForceT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
       auto pleg =
           Interpolation::LagrangePolynomial(vec_nodes.begin(), vec_nodes.end());
 
-      for (int idxq = 0; idxq < NQ; ++idxq) {
+      for (int idxq = 0; idxq < nq; ++idxq) {
         auto w_val = pleg(idxq, rad_source) / rad_source;
         auto w_prefactor = pleg.Derivative(idxq, rad_source) - w_val;
         std::size_t ridx = this->ltgT(idx, idxq);
@@ -70,8 +70,8 @@ SEM::calculateForceT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
 
 Eigen::MatrixXcd
 SEM::calculateForceAllT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgT(this->eu() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgT(this->eu() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(totlen, 2);
   double kval =
       std::sqrt(static_cast<double>(idxl) * (static_cast<double>(idxl) + 1.0));
@@ -85,7 +85,7 @@ SEM::calculateForceAllT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
       auto pleg =
           Interpolation::LagrangePolynomial(vec_nodes.begin(), vec_nodes.end());
 
-      for (int idxq = 0; idxq < NQ; ++idxq) {
+      for (int idxq = 0; idxq < nq; ++idxq) {
         auto w_val = pleg(idxq, rad_source) / rad_source;
         auto w_deriv = pleg.Derivative(idxq, rad_source);
         auto idx_v = this->ltgT(idx, idxq);
@@ -99,8 +99,8 @@ SEM::calculateForceAllT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
 
 Eigen::MatrixXcd
 SEM::calculateForceCoefficientsT(SourceInfo::EarthquakeCMT &cmt, int idxl) {
-  int NQ = m_mesh.NN();
-  totlen = this->ltgT(m_mesh.NE() - 1, NQ - 1) + 1;
+  int nq = m_mesh.NN();
+  totlen = this->ltgT(m_mesh.NE() - 1, nq - 1) + 1;
   Eigen::MatrixXcd vec_lforce = Eigen::MatrixXcd::Zero(2 * idxl + 1, 2);
 
   double theta_s = (90.0 - cmt.Latitude()) * EIGEN_PI / (180.0);

--- a/DSpecM1D/src/SEM/SEMReceivers.h
+++ b/DSpecM1D/src/SEM/SEMReceivers.h
@@ -8,8 +8,8 @@ namespace Full1D {
 Eigen::MatrixXcd
 SEM::rvFull(InputParameters &param, int idxl) {
   auto nrec = param.num_receivers();
-  using MATRIX = Eigen::MatrixXcd;
-  MATRIX vec_receiver = MATRIX::Zero(3 * nrec, 2 * idxl + 1);
+  using MatrixC = Eigen::MatrixXcd;
+  MatrixC vec_receiver = MatrixC::Zero(3 * nrec, 2 * idxl + 1);
   using namespace GSHTrans;
   int maxn = 1;
   auto i1 = std::complex<double>(0.0, 1.0);
@@ -43,8 +43,8 @@ SEM::rvFull(InputParameters &param, int idxl) {
 Eigen::MatrixXcd
 SEM::rvFullT(InputParameters &param, int idxl) {
   auto nrec = param.num_receivers();
-  using MATRIX = Eigen::MatrixXcd;
-  MATRIX vec_receiver = MATRIX::Zero(3 * nrec, 2 * idxl + 1);
+  using MatrixC = Eigen::MatrixXcd;
+  MatrixC vec_receiver = MatrixC::Zero(3 * nrec, 2 * idxl + 1);
   using namespace GSHTrans;
   auto i1 = std::complex<double>(0.0, 1.0);
   auto deg2rad = EIGEN_PI / 180.0;


### PR DESCRIPTION
### Motivation
- Apply the project's style guide conventions to improve naming consistency and readability in SEM internals ahead of first release.
- Reduce cognitive friction for future refactors by using `m_`-prefixed member names and consistent local/alias naming patterns.

### Description
- Renamed `prem_norm` member fields from `_length_norm`, `_mass_norm`, `_time_norm` to `m_lengthNorm`, `m_massNorm`, `m_timeNorm` while keeping the existing accessors `LengthNorm`, `MassNorm`, `TimeNorm` (file: `DSpecM1D/src/NormClass.h`).
- Replaced local quadrature-count variable `NQ` with `nq` in spheroidal, toroidal, and radial SEM force helper implementations (files: `DSpecM1D/src/SEM/SEMForceSpheroidal.h`, `DSpecM1D/src/SEM/SEMForceToroidal.h`, `DSpecM1D/src/SEM/SEMForceRadial.h`).
- Standardized the local matrix alias from `MATRIX` to `MatrixC` in SEM receiver assembly helpers (file: `DSpecM1D/src/SEM/SEMReceivers.h`).
- These edits are naming-only and do not change algorithmic behavior or public APIs beyond member-field renames that are internal to the `prem_norm` template.

### Testing
- Ran a local build attempt with `cmake --build . --parallel`, which failed due to there being no configured CMake cache in the repository root (expected in this environment).
- Ran a configure+build with `cmake -S . -B build && cmake --build build --parallel`, which failed during dependency fetching because `FetchContent` could not clone Eigen from GitLab (network/permission: HTTP 403) and also reported missing FFTW system development files; build did not complete.
- No unit tests were executed as the configure/build step could not complete due to external dependency/network failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7a6ad16b483208e1cb947c603ac65)